### PR TITLE
fix: catch remaining possible pdoexceptions

### DIFF
--- a/controller/profile.php
+++ b/controller/profile.php
@@ -44,20 +44,6 @@ class Profile
       }
     }
 
-    if (isset($_SESSION["loggedIn"]) && $_SESSION["balance"] < 0) {
-      $paymentMethods = $this->paymentMethod->getPaymentMethodsOf($_SESSION['username']);
-      include 'view/dashboard.php';
-      return null;
-    }
-
-    if (isset($_GET["switchWithdrawal"])) {
-      if ($this->user->updateWithdrawal($_SESSION['username'])) {
-        $_SESSION["isAutomatic"] = !$_SESSION["isAutomatic"];
-      } else {
-        $error = "An error as occurred.";
-      }
-    }
-
     if (isset($_POST['newPlan'])) {
       if ($this->user->updatePlan($_SESSION['username'], $_POST['newPlan'])) {
         $balanceDifference = $this->balanceService->calculateBalanceDifference($_SESSION['planName'], $_POST['newPlan']);
@@ -70,6 +56,20 @@ class Profile
         $_SESSION['planName'] = $_POST['newPlan'];
       } else {
         $error = "Could not update plan.";
+      }
+    }
+
+    if (isset($_SESSION["loggedIn"]) && $_SESSION["balance"] < 0) {
+      $paymentMethods = $this->paymentMethod->getPaymentMethodsOf($_SESSION['username']);
+      include 'view/dashboard.php';
+      return null;
+    }
+
+    if (isset($_GET["switchWithdrawal"])) {
+      if ($this->user->updateWithdrawal($_SESSION['username'])) {
+        $_SESSION["isAutomatic"] = !$_SESSION["isAutomatic"];
+      } else {
+        $error = "An error as occurred.";
       }
     }
 

--- a/model/Database.php
+++ b/model/Database.php
@@ -80,12 +80,20 @@ class Database
 
   public function rowCount()
   {
-    return $this->_statement->rowCount();
+    try {
+      return $this->_statement->rowCount();
+    } catch (PDOException $e) {
+      echo "<p class=\"has-text-black has-background-warning\">{$e->getMessage()}</p>";
+    }
   }
 
   public function lastInsertId()
   {
-    $this->_statement->execute();
-    return $this->_databaseHandler->lastInsertId();
+    try {
+      $this->_statement->execute();
+      return $this->_databaseHandler->lastInsertId();
+    } catch (PDOException $e) {
+      echo "<p class=\"has-text-black has-background-warning\">{$e->getMessage()}</p>";
+    }
   }
 }


### PR DESCRIPTION
change order of profile controller if statements because when a user
switched to a more expensive plan, they did not get booted to the
dashboard with the frozen block.